### PR TITLE
Set correct permissions before writing key

### DIFF
--- a/load
+++ b/load
@@ -20,8 +20,9 @@ delete_all_ssh_identities() {
 
 save_private_key_to_file() {
   delete_private_key_file
-  lpass show "$LASTPASS_NAME" --notes > "$PRIVATE_KEY"
+  touch "$PRIVATE_KEY"
   chmod 400 "$PRIVATE_KEY"
+  lpass show "$LASTPASS_NAME" --notes >> "$PRIVATE_KEY"
 }
 
 add_private_key() {


### PR DESCRIPTION
This avoids the (admittedly unlikely) scenario where an attacker is able to access the private key after it is written but before the correct permissions are set. Instead of setting permissions after creation, an empty file is created, permissions are set, and then the key is written.